### PR TITLE
use named routes and minor fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": "^8.1",
         "illuminate/support": "^10.0",
         "laravel/ui": "^4.2",
-        "livewire/livewire": "v3.0.0-beta.6",
+        "livewire/livewire": "^3.0@beta",
         "livewire/volt": "^1.0@beta",
         "laravel/folio": "^1.0@beta"
     },

--- a/src/GenesisPreset.php
+++ b/src/GenesisPreset.php
@@ -10,14 +10,11 @@ use Laravel\Ui\Presets\Preset;
 class GenesisPreset extends Preset
 {
     const NPM_PACKAGES_TO_ADD = [
-        '@tailwindcss/forms' => '^0.5',
-        '@tailwindcss/typography' => '^0.5',
-        'alpinejs' => '^3.8',
-        'autoprefixer' => '^10.4',
-        'resolve-url-loader' => '^3.1',
-        'sass' => '^1.3',
-        'sass-loader' => '^8.0',
-        'tailwindcss' => '^3.0',
+        '@tailwindcss/forms' => '^0.5.4',
+        '@tailwindcss/typography' => '^0.5.9',
+        'alpinejs' => '^3.12.3',
+        'autoprefixer' => '^10.4.14',
+        'tailwindcss' => '^3.3.3',
     ];
 
     const NPM_PACKAGES_TO_REMOVE = [
@@ -35,11 +32,6 @@ class GenesisPreset extends Preset
         static::updateFile(base_path('app/Http/Kernel.php'), function ($file) {
             $updatedFile = str_replace("'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,", "'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,\n\t\t'redirect-to-dashboard' => \App\Http\Middleware\RedirectToDashboard::class,", $file);
             return str_replace("'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,", "'password.confirm' => \App\Http\Middleware\RequirePassword::class,", $updatedFile);
-        });
-
-        // This is needed until page named routes are available in Folio
-        static::updateFile(base_path('app/Http/Middleware/Authenticate.php'), function ($file) {
-            return str_replace("route('login')", "'/auth/login'", $file);
         });
         
         // Run the Folio and volt install commands

--- a/stubs/default/app/Http/Controllers/Auth/EmailVerificationController.php
+++ b/stubs/default/app/Http/Controllers/Auth/EmailVerificationController.php
@@ -21,13 +21,13 @@ class EmailVerificationController extends Controller
         }
 
         if (Auth::user()->hasVerifiedEmail()) {
-            return redirect(route('home'));
+            return redirect()->route('home');
         }
 
         if (Auth::user()->markEmailAsVerified()) {
             event(new Verified(Auth::user()));
         }
 
-        return redirect(route('home'));
+        return redirect()->route('home');
     }
 }

--- a/stubs/default/app/Http/Controllers/Auth/LogoutController.php
+++ b/stubs/default/app/Http/Controllers/Auth/LogoutController.php
@@ -12,6 +12,6 @@ class LogoutController extends Controller
     {
         Auth::logout();
 
-        return redirect(route('home'));
+        return redirect()->route('home');
     }
 }

--- a/stubs/default/app/Http/Middleware/RedirectToDashboard.php
+++ b/stubs/default/app/Http/Middleware/RedirectToDashboard.php
@@ -17,7 +17,7 @@ class RedirectToDashboard
     public function handle(Request $request, Closure $next): Response
     {
         if (! Auth::guest()) {
-            return redirect('/dashboard');
+            return redirect()->route('dashboard');
         }
 
         return $next($request);

--- a/stubs/default/app/Http/Middleware/RequirePassword.php
+++ b/stubs/default/app/Http/Middleware/RequirePassword.php
@@ -73,7 +73,7 @@ class RequirePassword
                 ], 423);
             }
 
-            return redirect('/auth/password/confirm');
+            return redirect()->route('auth.password.confirm');
             // return $this->responseFactory->redirectGuest(
             //     $this->urlGenerator->route($redirectToRoute ?: 'password.confirm')
             // );

--- a/stubs/default/app/Notifications/ResetPasswordNotification.php
+++ b/stubs/default/app/Notifications/ResetPasswordNotification.php
@@ -94,7 +94,7 @@ class ResetPasswordNotification extends Notification
             return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
         }
 
-        return url('/auth/password/'.$this->token.'?email='.$notifiable->getEmailForPasswordReset());
+        return route('auth.password.token', ['token' => $this->token, 'email' => $notifiable->getEmailForPasswordReset()]);
     }
 
     /**

--- a/stubs/default/resources/views/components/ui/nav.blade.php
+++ b/stubs/default/resources/views/components/ui/nav.blade.php
@@ -3,7 +3,7 @@
     <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
             <!-- Logo -->
-            <a href="/dashboard" class="flex items-center shrink-0">
+            <a href="{{ route('dashboard') }}" class="flex items-center shrink-0">
                 <x-ui.logo class="block w-auto h-8 text-gray-800 fill-current dark:text-gray-200" />
             </a>
 
@@ -14,10 +14,10 @@
                 @endphp
                 <!-- Navigation Links -->
                 <div :class="{'block bg-white relative z-50 w-full h-auto px-4 py-5 left-0 mt-16': open, 'hidden': ! open}" class="items-center space-y-3 sm:space-x-3 sm:space-y-0 sm:mt-0 sm:bg-transparent sm:p-0 sm:relative sm:flex sm:-my-px sm:ml-8" x-cloak>
-                    @foreach($navLinks as $title => $link)
-                        <a href="/{{ $link }}"
+                    @foreach($navLinks as $title => $route)
+                        <a href="{{ route($route) }}"
                             :class="{ 'block w-full': open, '': ! open }"
-                            class="rounded-md px-4 sm:px-3 py-2.5 sm:py-2 sm:w-auto text-sm group relative @if(Request::is($link)){{ 'text-gray-800 bg-gray-100/70 font-semibold' }}@else{{ 'text-gray-600 font-medium hover:bg-gray-100/70' }}@endif">
+                            class="rounded-md px-4 sm:px-3 py-2.5 sm:py-2 sm:w-auto text-sm group relative @if(Request::is($route)){{ 'text-gray-800 bg-gray-100/70 font-semibold' }}@else{{ 'text-gray-600 font-medium hover:bg-gray-100/70' }}@endif">
                             <span>{{ $title }}</span>
                         </a>
                     @endforeach
@@ -38,7 +38,7 @@
                     <div x-show="dropdownOpen" @click.away="dropdownOpen=false" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="transform opacity-0 sm:scale-95" x-transition:enter-end="transform opacity-100 sm:scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 sm:scale-100" x-transition:leave-end="transform opacity-0 sm:scale-95" 
                         class="absolute top-0 right-0 z-50 w-full mt-16 sm:mt-12 sm:origin-top-right sm:w-40" x-cloak>
                         <div class="p-4 pt-0 mt-1 space-y-3 text-gray-600 bg-white sm:p-1 sm:space-y-0 sm:border sm:shadow-md sm:rounded-md border-gray-200/70">
-                            <a href="/profile/edit" class="relative flex cursor-pointer hover:text-gray-700 select-none hover:bg-gray-100/70 items-center rounded py-2 px-4 sm:px-2 sm:py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
+                            <a href="{{ route('profile.edit') }}" class="relative flex cursor-pointer hover:text-gray-700 select-none hover:bg-gray-100/70 items-center rounded py-2 px-4 sm:px-2 sm:py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mr-2"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
                                 <span>Edit Profile</span>
                             </a>

--- a/stubs/default/resources/views/pages/auth/login.blade.php
+++ b/stubs/default/resources/views/pages/auth/login.blade.php
@@ -2,9 +2,10 @@
 
 use App\Models\User;
 use Illuminate\Auth\Events\Login;
-use function Laravel\Folio\{middleware};
+use function Laravel\Folio\{middleware, name};
 use function Livewire\Volt\{state, rules};
 
+name('login');
 middleware(['guest']);
 state(['email' => '', 'password' => '', 'remember' => false]);
 rules(['email' => 'required|email', 'password' => 'required']);
@@ -30,14 +31,14 @@ $authenticate = function(){
     <div class="flex flex-col items-stretch justify-center w-screen h-screen sm:items-center">
         
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
-            <x-ui.link href="/">
+            <x-ui.link href="{{ route('index') }}">
                 <x-ui.logo class="w-auto h-12 mx-auto text-gray-800 fill-current" />
             </x-ui.link>
 
             <h2 class="mt-6 text-3xl font-extrabold leading-9 text-center text-gray-800">Sign in to your account</h2>
             <div class="mt-2 text-sm leading-5 text-center text-gray-600 max-w">
                 <span>Or</span>
-                <x-ui.text-link href="/auth/register">create a new account</x-ui.text-link>
+                <x-ui.text-link href="{{ route('register') }}">create a new account</x-ui.text-link>
             </div>
         </div>
 
@@ -51,7 +52,7 @@ $authenticate = function(){
 
                         <div class="flex items-center justify-between mt-6 text-sm leading-5">
                             <x-ui.checkbox label="Remember me" id="remember" name="remember" wire:model="remember" />
-                            <x-ui.text-link href="/auth/password/reset">Forgot your password?</x-ui.text-link>
+                            <x-ui.text-link href="{{ route('auth.password.reset') }}">Forgot your password?</x-ui.text-link>
                         </div>
 
                         <x-ui.button type="primary" submit="true">Sign in</x-ui.button>

--- a/stubs/default/resources/views/pages/auth/password/[token].blade.php
+++ b/stubs/default/resources/views/pages/auth/password/[token].blade.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 
+use function Laravel\Folio\name;
 use function Livewire\Volt\{state, rules, mount};
 
+name('auth.password.token');
 state(['token', 'email', 'password', 'passwordConfirmation']);
 rules(['token' => 'required', 'email' => 'required|email', 'password' => 'required|min:8|same:passwordConfirmation']);
 
@@ -52,7 +54,7 @@ $resetPassword = function(){
 <x-layouts.app>
     <div class="flex flex-col items-stretch justify-center w-screen h-screen sm:items-center">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
-            <x-ui.link href="/">
+            <x-ui.link href="{{ route('index') }}">
                 <x-ui.logo class="w-auto h-12 mx-auto text-gray-800 fill-current" />
             </x-ui.link>
             <h2 class="mt-6 text-3xl font-extrabold leading-9 text-center text-gray-800">Reset password</h2>

--- a/stubs/default/resources/views/pages/auth/password/confirm.blade.php
+++ b/stubs/default/resources/views/pages/auth/password/confirm.blade.php
@@ -2,8 +2,10 @@
 
     namespace App\Http\Livewire\Auth\Passwords;
 
+    use function Laravel\Folio\name;
     use function Livewire\Volt\{state, rules};
 
+    name('auth.password.confirm');
     state(['password' => '']);
     rules(['password' => 'required|current_password']);
 
@@ -19,7 +21,7 @@
 <x-layouts.app>
     <div class="flex flex-col items-stretch justify-center w-screen h-screen sm:items-center">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
-            <x-ui.link href="/">
+            <x-ui.link href="{{ route('index') }}">
                 <x-ui.logo class="w-auto h-12 mx-auto text-gray-800 fill-current" />
             </x-ui.link>
 
@@ -37,7 +39,7 @@
                     <form wire:submit="confirm" class="space-y-6">
                         <x-ui.input label="Password" type="password" id="password" name="password" wire:model="password" />
                         <div class="flex items-center justify-end text-sm">
-                            <x-ui.text-link href="/auth/password/reset">Forgot your password?</x-ui.text-link>
+                            <x-ui.text-link href="{{ route('auth.password.reset') }}">Forgot your password?</x-ui.text-link>
                         </div>
                         <x-ui.button type="primary" submit="true">Confirm password</x-ui.button>
                     </form>

--- a/stubs/default/resources/views/pages/auth/password/reset.blade.php
+++ b/stubs/default/resources/views/pages/auth/password/reset.blade.php
@@ -1,8 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Password;
+use function Laravel\Folio\name;
 use function Livewire\Volt\{state, rules};
 
+name('auth.password.reset');
 state(['email' => null, 'emailSentMessage' => false]);
 rules(['email' => 'required|email']);
 
@@ -28,7 +30,7 @@ $sendResetPasswordLink = function(){
 
     <div class="flex flex-col items-stretch justify-center w-screen h-screen sm:items-center">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
-            <x-ui.link href="/">
+            <x-ui.link href="{{ route('index') }}">
                 <x-ui.logo class="w-auto h-12 mx-auto text-gray-800 fill-current" />
             </x-ui.link>
 
@@ -37,7 +39,7 @@ $sendResetPasswordLink = function(){
             </h2>
             <div class="mt-2 text-sm leading-5 text-center text-gray-600 max-w">
                 <span>Or</span>
-                <x-ui.text-link href="/auth/login">return to login</x-ui.text-link>
+                <x-ui.text-link href="{{ route('login') }}">return to login</x-ui.text-link>
             </div>
         </div>
 

--- a/stubs/default/resources/views/pages/auth/register.blade.php
+++ b/stubs/default/resources/views/pages/auth/register.blade.php
@@ -5,9 +5,10 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Auth\Events\Registered;
 
-use function Laravel\Folio\{middleware};
+use function Laravel\Folio\{middleware, name};
 use function Livewire\Volt\{state, rules};
 
+name('register');
 middleware(['guest']);
 state(['name' => '', 'email' => '', 'password' => '', 'passwordConfirmation' => '']);
 rules(['name' => 'required', 'email' => 'required|email|unique:users', 'password' => 'required|min:8|same:passwordConfirmation']);
@@ -37,13 +38,13 @@ $register = function(){
     <div class="flex flex-col items-stretch justify-center w-screen h-screen sm:items-center">
         
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
-            <x-ui.link href="/">
+            <x-ui.link href="{{ route('index') }}">
                 <x-ui.logo class="w-auto h-12 mx-auto text-gray-800 fill-current" />
             </x-ui.link>
             <h2 class="mt-6 text-3xl font-extrabold leading-9 text-center text-gray-800">Create a new account</h2>
             <div class="mt-2 text-sm leading-5 text-center text-gray-600 max-w">
                 <span>Or</span>
-                <x-ui.text-link href="/auth/login">sign in to your account</x-ui.text-link>
+                <x-ui.text-link href="{{ route('login') }}">sign in to your account</x-ui.text-link>
             </div>
         </div>
 

--- a/stubs/default/resources/views/pages/auth/verify.blade.php
+++ b/stubs/default/resources/views/pages/auth/verify.blade.php
@@ -2,8 +2,9 @@
 
     use Illuminate\Auth\Events\Verified;
     use Illuminate\Support\Facades\Auth;
-    use function Laravel\Folio\{middleware};
+    use function Laravel\Folio\{middleware, name};
 
+    name('auth.verify');
     middleware(['auth', 'throttle:6,1']);
 
     $resend = function(){
@@ -26,7 +27,7 @@
 
     <div class="flex flex-col items-stretch justify-center w-screen h-screen sm:items-center">
         <div class="sm:mx-auto sm:w-full sm:max-w-md">
-            <x-ui.link href="/">
+            <x-ui.link href="{{ route('index') }}">
                 <x-ui.logo class="w-auto h-16 mx-auto text-gray-800" />
             </x-ui.link>
 

--- a/stubs/default/resources/views/pages/dashboard/index.blade.php
+++ b/stubs/default/resources/views/pages/dashboard/index.blade.php
@@ -1,8 +1,9 @@
 <?php
 
-use function Laravel\Folio\{middleware};
+use function Laravel\Folio\{middleware, name};
 //use function Livewire\Volt\{state};
 
+name('dashboard');
 middleware(['auth', 'verified']);
 
 ?>

--- a/stubs/default/resources/views/pages/index.blade.php
+++ b/stubs/default/resources/views/pages/index.blade.php
@@ -1,8 +1,9 @@
 <?php
 
-use function Laravel\Folio\{middleware};
+use function Laravel\Folio\{middleware, name};
 use function Livewire\Volt\{state, rules};
 
+name('index');
 middleware(['redirect-to-dashboard']);
 
 ?>
@@ -12,7 +13,7 @@ middleware(['redirect-to-dashboard']);
     @volt('home')
         <div class="flex flex-col items-center justify-center min-h-screen pt-6 sm:pt-0 dark:bg-gray-900" x-cloak>
             <div class="sm:mx-auto sm:w-full sm:max-w-md">
-                <x-ui.link href="/">
+                <x-ui.link href="{{ route('index') }}">
                     <x-ui.logo class="w-auto h-12 mx-auto text-gray-800 fill-current" />
                 </x-ui.link>
 
@@ -20,9 +21,9 @@ middleware(['redirect-to-dashboard']);
                     Welcome to Genesis
                 </h1>
                 <div class="mt-2 text-sm leading-5 text-center text-gray-600 max-w">
-                    <x-ui.text-link href="/auth/login">Login</x-ui.text-link>
+                    <x-ui.text-link href="{{ route('login') }}">Login</x-ui.text-link>
                     or
-                    <x-ui.text-link href="/auth/register">create a new account</x-ui.text-link>
+                    <x-ui.text-link href="{{ route('register') }}">create a new account</x-ui.text-link>
                 </div>
             </div>
 

--- a/stubs/default/resources/views/pages/learn/index.blade.php
+++ b/stubs/default/resources/views/pages/learn/index.blade.php
@@ -2,8 +2,10 @@
 
 use Illuminate\Support\Facades\Http;
 
-use function Laravel\Folio\{middleware};
+use function Laravel\Folio\{middleware, name};
 use function Livewire\Volt\{with, state, rules, mount};
+
+name('learn');
 middleware(['auth', 'verified']);
 
 $res = Http::get('https://raw.githubusercontent.com/thedevdojo/genesis/main/README.md');

--- a/stubs/default/resources/views/pages/profile/edit.blade.php
+++ b/stubs/default/resources/views/pages/profile/edit.blade.php
@@ -4,10 +4,11 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\Request;
-use function Laravel\Folio\{middleware};
+use function Laravel\Folio\{middleware, name};
 use function Livewire\Volt\{with, state, rules, mount};
 use Illuminate\Validation\Rule;
 
+name('profile.edit');
 middleware(['auth', 'verified']);
 rules(['new_password' => 'required|confirmed|min:6']);
 

--- a/stubs/default/tailwind.config.js
+++ b/stubs/default/tailwind.config.js
@@ -16,14 +16,7 @@ module.exports = {
     },
     content: [
         './app/**/*.php',
-        './resources/**/*.html',
-        './resources/**/*.js',
-        './resources/**/*.jsx',
-        './resources/**/*.ts',
-        './resources/**/*.tsx',
-        './resources/**/*.php',
-        './resources/**/*.vue',
-        './resources/**/*.twig',
+        "./resources/**/*.{php,html,js,jsx,ts,tsx,vue,twig}",
     ],
     plugins: [
         require('@tailwindcss/forms'),

--- a/stubs/default/tests/Feature/Auth/LogoutTest.php
+++ b/stubs/default/tests/Feature/Auth/LogoutTest.php
@@ -17,7 +17,7 @@ test('an authenticated user can log out', function () {
 
 test('an unauthenticated user can not log out', function () {
     $this->post(route('logout'))
-        ->assertRedirect('/auth/login');
+        ->assertRedirect(route('login'));
 
     expect(Auth::check())->toBeFalse();
 });

--- a/stubs/default/tests/Feature/Auth/Passwords/ConfirmTest.php
+++ b/stubs/default/tests/Feature/Auth/Passwords/ConfirmTest.php
@@ -19,7 +19,7 @@ test('a user must confirm their password before visiting a protected page', func
     $this->be($user);
 
     $this->get('/must-be-confirmed')
-        ->assertRedirect('/auth/password/confirm');
+        ->assertRedirect(route('auth.password.confirm'));
 });
 
 test('a user must enter a password to confirm it', function () {


### PR DESCRIPTION
- Switched over to use the new named routes just released in Folio.
- Used the recommended version constraint for Livewire 3 (^3.0@beta), should fix #6
- Added more verbose versions for npm dependencies, this should fix #8 when people are using things like pnpm
- Removed sass, sass-loader, and resolve-url-loader as they didn't seem to be used (and tailwind doesn't recommend you use any preprocessors like that)