### PR TITLE
Add closing Div to Toast

### DIFF
--- a/stubs/class/resources/views/livewire/toast.blade.php
+++ b/stubs/class/resources/views/livewire/toast.blade.php
@@ -48,6 +48,7 @@
             `
         "
         class="relative space-y-5">
+    </div>
     <template x-teleport="body">
         <ul 
             x-data="{ 

--- a/stubs/default/resources/views/livewire/toast.blade.php
+++ b/stubs/default/resources/views/livewire/toast.blade.php
@@ -48,6 +48,7 @@
             `
         "
         class="relative space-y-5">
+    </div>
     <template x-teleport="body">
         <ul 
             x-data="{ 


### PR DESCRIPTION
Livewire was throwing an "unclosed bracket" error originating from the toast component. 

This PR adds the closing Div to the functional and class based stubs.