### PR TITLE
Update livewire/volt to ^1.10.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/folio": "*",
         "laravel/framework": "^11.0|^12.0",
         "laravel/tinker": "^2.10.1",
-        "livewire/volt": "^1.7"
+        "livewire/volt": "^1.10.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",


### PR DESCRIPTION
## Summary

- Updates livewire/volt from ^1.7 to ^1.10.2

## Changes

- Volt 1.10.2 includes bug fixes and improvements
- Adds compatibility with Livewire 4 and Laravel 12
- Includes fix for TypeError when `Blade::getPath()` returns null during view caching

## Related

This update includes fixes from livewire/volt#150.